### PR TITLE
#14: @typescript-eslint/explicit-function-return-type: error にレベル変更

### DIFF
--- a/packages/eslint-config-nuxt3-typescript/index.js
+++ b/packages/eslint-config-nuxt3-typescript/index.js
@@ -16,5 +16,14 @@ module.exports = {
     ],
     '@typescript-eslint/no-unused-vars': 'off',
     'unused-imports/no-unused-imports': 'error',
+    '@typescript-eslint/explicit-function-return-type': 'off',
   },
+  overrides: [
+    {
+      files: ['*.ts', '*.tsx', '*.vue'],
+      rules: {
+        '@typescript-eslint/explicit-function-return-type': 'error',
+      },
+    },
+  ],
 };


### PR DESCRIPTION
## Issue

closed #14 .

## 内容

- [x] `@typescript-eslint/explicit-function-return-type`を**error**にoverrideしました

### 備考

## 本 PR で対応しない内容

## レビュアー確認項目

- [x] 意図した設定になっているか